### PR TITLE
Substitui suporte ao espanhol pelo português na ferramenta de OCR do BigLinux.

### DIFF
--- a/shared/Packages-Root
+++ b/shared/Packages-Root
@@ -239,7 +239,6 @@ wireplumber
 breeze-icons
 helvum
 chmlib
-tesseract-data-spa
 
 ## Fonts
 ttf-dejavu
@@ -360,7 +359,8 @@ powertop
   biglinux-bash-config
   biglinux-zsh-config
   bigocrpdf
-#     tesseract-data-por
+  tesseract-data-por
+#     tesseract-data-spa
 #     tesseract-data-eng
   tts-biglinux
 #     rhvoice-voice-leticia-f123


### PR DESCRIPTION
Por ser uma distribuição brasileira, acredito que a ferramenta de OCR deveria ter suporte pelo menos ao português (pré-instalado).
Atualmente, só tem suporte ao espanhol, e o pacote associado ao espanhol 'tesseract-data-spa' estava mal categorizado na seção 'Sound/Audio/Video'.

Este é o primeiro commit e pull request que faço a um projeto open source, se eu estiver fazendo algo errado, me avisem por favor.